### PR TITLE
Bf ipsec full

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@
 #  initialize & set some vars
 # ============================
 
-AC_INIT([strongSwan],[5.9.0])
+AC_INIT([strongSwan],[BF-5.9.0])
 AM_INIT_AUTOMAKE(m4_esyscmd([
 	echo tar-ustar
 	echo subdir-objects
@@ -31,6 +31,23 @@ AM_INIT_AUTOMAKE(m4_esyscmd([
 		*) echo serial-tests;;
 	esac
 ]))
+
+# backwards compat with older pkg-config
+# - pull in AC_DEFUN from pkg.m4
+m4_ifndef([PKG_CHECK_VAR], [
+# PKG_CHECK_VAR(VARIABLE, MODULE, CONFIG-VARIABLE,
+# [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND])
+# -------------------------------------------
+# Retrieves the value of the pkg-config variable for the given module.
+AC_DEFUN([PKG_CHECK_VAR],
+[AC_REQUIRE([PKG_PROG_PKG_CONFIG])dnl
+AC_ARG_VAR([$1], [value of $3 for $2, overriding pkg-config])dnl
+_PKG_CONFIG([$1], [variable="][$3]["], [$2])
+AS_VAR_COPY([$1], [pkg_cv_][$1])
+AS_VAR_IF([$1], [""], [$5], [$4])dnl
+])# PKG_CHECK_VAR
+])
+
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES])
 AC_CONFIG_MACRO_DIR([m4/config])
 AC_CONFIG_HEADERS([config.h])
@@ -369,7 +386,7 @@ AC_SUBST(PLUGIN_CFLAGS)
 AC_PROG_CC
 AM_PROG_CC_C_O
 
-AC_LIB_PREFIX
+m4_pattern_allow([AC_LIB_PREFIX])
 AC_C_BIGENDIAN
 
 # =========================

--- a/src/include/linux/xfrm.h
+++ b/src/include/linux/xfrm.h
@@ -503,6 +503,7 @@ struct xfrm_user_offload {
 };
 #define XFRM_OFFLOAD_IPV6	1
 #define XFRM_OFFLOAD_INBOUND	2
+#define XFRM_OFFLOAD_FULL	4
 
 #ifndef __KERNEL__
 /* backwards compatibility for userspace */

--- a/src/libcharon/plugins/vici/vici_config.c
+++ b/src/libcharon/plugins/vici/vici_config.c
@@ -1031,6 +1031,7 @@ CALLBACK(parse_hw_offload, bool,
 		{ "no",		HW_OFFLOAD_NO	},
 		{ "yes",	HW_OFFLOAD_YES	},
 		{ "auto",	HW_OFFLOAD_AUTO	},
+		{ "full",	HW_OFFLOAD_FULL	},
 	};
 	int d;
 

--- a/src/libstrongswan/ipsec/ipsec_types.c
+++ b/src/libstrongswan/ipsec/ipsec_types.c
@@ -37,10 +37,11 @@ ENUM(ipcomp_transform_names, IPCOMP_NONE, IPCOMP_LZJH,
 	"IPCOMP_LZJH"
 );
 
-ENUM(hw_offload_names, HW_OFFLOAD_NO, HW_OFFLOAD_AUTO,
+ENUM(hw_offload_names, HW_OFFLOAD_NO, HW_OFFLOAD_FULL,
 	"no",
 	"yes",
 	"auto",
+	"full",
 );
 
 ENUM(dscp_copy_names, DSCP_COPY_OUT_ONLY, DSCP_COPY_NO,

--- a/src/libstrongswan/ipsec/ipsec_types.h
+++ b/src/libstrongswan/ipsec/ipsec_types.h
@@ -126,6 +126,7 @@ enum hw_offload_t {
 	HW_OFFLOAD_NO = 0,
 	HW_OFFLOAD_YES = 1,
 	HW_OFFLOAD_AUTO = 2,
+	HW_OFFLOAD_FULL = 3,
 };
 
 /**

--- a/testing/testing.conf
+++ b/testing/testing.conf
@@ -31,7 +31,7 @@ fi
 : ${KERNELPATCH=ha-5.0-abicompat.patch.bz2}
 
 # strongSwan version used in tests
-: ${SWANVERSION=5.9.0}
+: ${SWANVERSION=BF-5.9.0}
 
 # Build directory where the guest kernel and images will be built
 : ${BUILDDIR=$TESTDIR/build}


### PR DESCRIPTION
Adding ipsec full hw-offload feature to strongswan.
In IPsec full offload (also called unaware mode) HW fully offloads the ESP data-path including: crypto, transport mode encapsulation, replay protection, ESP sequence number generation, ESN, error reporting
Full offload does both the crypto operations and packet encapsulation in HW, which greatly reduce the SW overhead.

Changes:
- new flag HW_OFFLOAD_FULL
- modified config_hw_offload() to support the new flag
- new value in swanctl.conf: connections.<conn>.children.<child>.hw_offload

note: includes changes to configure.ac file to allow build strongswan on centos.
 