### PR TITLE
pka: check if platform is crypto enabled

### DIFF
--- a/init/systemd-starter/strongswan-starter.service.in
+++ b/init/systemd-starter/strongswan-starter.service.in
@@ -6,7 +6,7 @@ After=syslog.target network-online.target
 ExecStartPre=/bin/cp -f /etc/ssl/openssl.cnf.orig /etc/ssl/openssl.cnf
 ExecStart=@SBINDIR@/@IPSEC_SCRIPT@ start --nofork
 ExecStartPost=/bin/sleep 2
-ExecStartPost=/bin/cp -f /etc/ssl/openssl.cnf.mlnx /etc/ssl/openssl.cnf
+ExecStartPost=/bin/bash -c 'if lscpu | grep Flags | grep sha1 | grep sha2 | grep -q aes 2>/dev/null; then /bin/cp -f /etc/ssl/openssl.cnf.mlnx /etc/ssl/openssl.cnf; fi'
 StandardOutput=syslog
 Restart=on-abnormal
 

--- a/systemd-conf/strongswan-starter.service.in.centos
+++ b/systemd-conf/strongswan-starter.service.in.centos
@@ -6,7 +6,7 @@ After=syslog.target network-online.target
 ExecStartPre=/bin/cp -f /etc/pki/tls/openssl.cnf.orig /etc/pki/tls/openssl.cnf
 ExecStart=@SBINDIR@/@IPSEC_SCRIPT@ start --nofork
 ExecStartPost=/bin/sleep 2
-ExecStartPost=/bin/cp -f /etc/pki/tls/openssl.cnf.mlnx /etc/pki/tls/openssl.cnf
+ExecStartPost=/bin/bash -c 'if lscpu | grep Flags | grep sha1 | grep sha2 | grep -q aes 2>/dev/null; then /bin/cp -f /etc/pki/tls/openssl.cnf.mlnx /etc/pki/tls/openssl.cnf; fi'
 StandardOutput=syslog
 Restart=on-abnormal
 


### PR DESCRIPTION
* Platform is crypto enabled if 'aes', 'sha1' and 'sha2'
flags are present in the output of `lscpu`.

* openssl.cnf is the config file used by OpenSSL.

* openssl.cnf.mlnx links to PKA engine and this can only be used if
platform is crypto enabled.

Signed-off-by: Mahantesh Salimath <mahantesh@nvidia.com>