### PR TITLE
Added HW offload auto support for full offload and added crypto offlo…

### DIFF
--- a/src/libcharon/plugins/vici/vici_config.c
+++ b/src/libcharon/plugins/vici/vici_config.c
@@ -1042,7 +1042,8 @@ CALLBACK(parse_hw_offload, bool,
 {
 	enum_map_t map[] = {
 		{ "no",		HW_OFFLOAD_NO	},
-		{ "yes",	HW_OFFLOAD_YES	},
+		{ "yes",	HW_OFFLOAD_CRYPTO },
+		{ "crypto",	HW_OFFLOAD_CRYPTO },
 		{ "auto",	HW_OFFLOAD_AUTO	},
 		{ "full",	HW_OFFLOAD_FULL	},
 	};

--- a/src/libstrongswan/ipsec/ipsec_types.h
+++ b/src/libstrongswan/ipsec/ipsec_types.h
@@ -124,7 +124,7 @@ extern enum_name_t *ipcomp_transform_names;
  */
 enum hw_offload_t {
 	HW_OFFLOAD_NO = 0,
-	HW_OFFLOAD_YES = 1,
+	HW_OFFLOAD_CRYPTO = 1,
 	HW_OFFLOAD_AUTO = 2,
 	HW_OFFLOAD_FULL = 3,
 };


### PR DESCRIPTION
…ad flag

Previously, when configuring hw_offload = auto, it didn't configure full HW offload. Now when configuring hw_offload = auto, we try full HW offload and if it fails then crypto HW offload and if that fails then no offload. Also removed HW_OFFLOAD_YES and replaces with HW_OFFLOAD_CRYPTO since we now have HW_OFFLOAD_FULL and HW_OFFLOAD_YES doesn't make sense. Also added the flag crypto (hw_offload = crypto) to the swanctl.conf files and kept the yes flag as legacy.

Signed-off-by: Feras Bisharat <fbisharat@nvidia.com>